### PR TITLE
Added waitDelay argument to Browser to fix issue #1

### DIFF
--- a/adm.js
+++ b/adm.js
@@ -11,7 +11,9 @@ var prompt = require('prompt');
 var config = require('config');
 const Browser = require('zombie');
 Browser.silent = true;
-const browser = new Browser();
+const browser = new Browser({
+    waitDuration: 29*1000
+});
 var request = require('request');
 
 var ableton = {


### PR DESCRIPTION
This allows the account page to fully load on slow internet before querying the download elements.

This fix was related to https://github.com/assaf/zombie/issues/953. 